### PR TITLE
Rollback streamlit version to 1.36.0 for hf space compat.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,3 +32,24 @@ jobs:
     - name: Run tests
       run: |
         pytest tests
+
+  test-deploy:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[app]
+    
+    - name: Run deploy tests
+      run: |
+        streamlit run serve/app.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,24 +32,3 @@ jobs:
     - name: Run tests
       run: |
         pytest tests
-
-  test-deploy:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.11"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[app]
-    
-    - name: Run deploy tests
-      run: |
-        streamlit run serve/app.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.38.0
+streamlit>=1.36.0
 plotly
 numpy
 scipy

--- a/serve/tasks/combustion.py
+++ b/serve/tasks/combustion.py
@@ -257,7 +257,7 @@ if "time_range" not in st.session_state:
     st.session_state.time_range = (0, increment)
 
 
-@st.fragment(run_every=1e-3 if st.session_state.play else None)
+@st.experimental_fragment(run_every=1e-3 if st.session_state.play else None)
 def draw_com_drifts_plot():
     if st.session_state.play:
         start, end = st.session_state.time_range


### PR DESCRIPTION
HF space now only supports `streamlit` up to `1.36.0`. This causes the missing `fragment` decorator. Change back to `experimental_fragment`